### PR TITLE
Fixes bug #110

### DIFF
--- a/nix/node-env.nix
+++ b/nix/node-env.nix
@@ -330,7 +330,7 @@ let
       extraArgs = removeAttrs args [ "name" "dependencies" "buildInputs" "dontStrip" "dontNpmInstall" "preRebuild" "unpackPhase" "buildPhase" ];
     in
     stdenv.mkDerivation ({
-      name = "node-${name}-${version}";
+      name = "node_${name}-${version}";
       buildInputs = [ tarWrapper python nodejs ]
         ++ stdenv.lib.optional (stdenv.isLinux) utillinux
         ++ stdenv.lib.optional (stdenv.isDarwin) libtool


### PR DESCRIPTION
Currently, npm package names are generated prefixed by "node-". This causes issues, because when parsing package names, nix stops at the first "-", expecting a version number to come afterwards. This causes nix to think all your npm packages are named "node", so every time you install a new npm package, all your old ones are removed (nix removes the package named "node", which because of this bug, includes all of them).